### PR TITLE
chore: add .vite/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ node_modules/
 dist/
 *.tsbuildinfo
 
+# Vite cache
+.vite/
+
 # IDE and editors
 .vscode/*
 !.vscode/extensions.json


### PR DESCRIPTION
## Summary

Add `.vite/` directory to `.gitignore` to prevent Vite's dependency cache from being tracked in version control.

## Changes

- Added `.vite/` entry under "# Vite cache" section in `.gitignore`

## Why

The `.vite/` directory is created by Vite during development to cache dependency pre-bundling. This is a build artifact that:
- Is automatically regenerated
- Is machine/environment specific
- Should not be committed to source control