### PR TITLE
docs: add branch workflow instructions and protections

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Prevent direct commits to main and release branches
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$branch" = "main" ] || [ "$branch" = "release" ]; then
+  echo "❌ Direct commits to '$branch' branch are not allowed."
+  echo ""
+  echo "Please create a feature branch first:"
+  echo "  git checkout -b feature-<name>"
+  echo ""
+  echo "Or use the start prompt:"
+  echo "  /start"
+  exit 1
+fi

--- a/.github/agents/speckit.implement.agent.md
+++ b/.github/agents/speckit.implement.agent.md
@@ -12,6 +12,19 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
+0. **Branch Setup (REQUIRED before any implementation)**:
+   - Verify git hooks are configured: `git config core.hooksPath` should return `.githooks`
+     - If not configured, run: `git config core.hooksPath .githooks`
+   - Check current branch: `git branch --show-current`
+   - If on `main` or `release`:
+     1. Sync main to latest: `git checkout main && git fetch origin && git pull origin main`
+     2. Create feature branch: `git checkout -b feature-<feature-name>` (derive name from spec/plan)
+     3. Confirm branch: `git branch --show-current`
+   - If already on a feature branch:
+     1. Check for uncommitted changes: `git status`
+     2. If clean, optionally rebase on main: `git fetch origin && git rebase origin/main`
+   - **STOP** and confirm with user if branch setup encounters conflicts or errors
+
 1. Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
 2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):

--- a/.github/agents/speckit.tasks.agent.md
+++ b/.github/agents/speckit.tasks.agent.md
@@ -21,6 +21,17 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
+0. **Branch Setup (REQUIRED before generating tasks for new work)**:
+   - Verify git hooks are configured: `git config core.hooksPath` should return `.githooks`
+     - If not configured, run: `git config core.hooksPath .githooks`
+   - Check current branch: `git branch --show-current`
+   - If on `main` or `release`:
+     1. Sync main to latest: `git checkout main && git fetch origin && git pull origin main`
+     2. Create feature branch: `git checkout -b feature-<feature-name>` (derive name from spec/plan)
+     3. Confirm branch: `git branch --show-current`
+   - If already on a feature branch: Proceed (optionally remind user to ensure branch is up to date)
+   - **Note**: Tasks should be generated on a feature branch, not directly on `main` or `release`
+
 1. **Setup**: Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
 2. **Load design documents**: Read from FEATURE_DIR:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,9 +34,45 @@ This project uses **Cloudflare Pages** with Git integration for automatic deploy
 
 **Workflow**: `feature branch` → `main` (beta testing) → `release` (production)
 
+### Starting New Work (REQUIRED)
+
+**Before starting any new feature or task, ALWAYS:**
+
+1. **Sync main to latest remote state**:
+   ```bash
+   git checkout main
+   git fetch origin
+   git pull origin main
+   ```
+
+2. **Create a feature branch from updated main**:
+   ```bash
+   git checkout -b feature-<name>
+   ```
+   - Use descriptive branch names: `feature-add-score-tracking`, `fix-win-detection`, `docs-api-reference`
+
+3. **Verify you're on the feature branch** before making changes:
+   ```bash
+   git branch --show-current
+   ```
+
+### Branch Rules
+
 - Always create feature branches from `main`
+- Never commit directly to `main` or `release`
 - Merge to `main` for beta user testing
 - Only merge `main` to `release` for production releases
+
+### Git Hooks (Local Enforcement)
+
+This repo uses a pre-commit hook to prevent direct commits to `main` and `release`.
+
+**Setup (required after cloning):**
+```bash
+git config core.hooksPath .githooks
+```
+
+The hook will block commits with a helpful error message if you accidentally try to commit on a protected branch.
 
 ## Recent Changes
 

--- a/.github/prompts/start.task.prompt.md
+++ b/.github/prompts/start.task.prompt.md
@@ -1,0 +1,98 @@
+````prompt
+# Start New Work
+
+Sync main branch with remote and create a feature branch before starting any new work.
+
+## Instructions
+
+### Step 0: Verify Git Hooks
+
+1. **Check git hooks are configured**:
+   ```bash
+   git config core.hooksPath
+   ```
+   - Should return `.githooks`
+   - If empty or different, run: `git config core.hooksPath .githooks`
+
+### Step 1: Sync Main Branch
+
+1. **Stash any uncommitted changes** (if needed):
+   ```bash
+   git stash
+   ```
+
+2. **Switch to main branch**:
+   ```bash
+   git checkout main
+   ```
+
+3. **Fetch latest from remote**:
+   ```bash
+   git fetch origin
+   ```
+
+4. **Pull latest changes**:
+   ```bash
+   git pull origin main
+   ```
+
+5. **Verify main is up to date**:
+   ```bash
+   git log --oneline -3
+   ```
+
+### Step 2: Create Feature Branch
+
+6. **Create and switch to feature branch**:
+   ```bash
+   git checkout -b feature-<name>
+   ```
+   - Replace `<name>` with a descriptive name (e.g., `feature-add-score-tracking`)
+   - Use kebab-case for branch names
+   - Prefix with: `feature-`, `fix-`, `docs-`, `refactor-`, or `chore-`
+
+7. **Verify you're on the new branch**:
+   ```bash
+   git branch --show-current
+   ```
+
+8. **Restore stashed changes** (if applicable):
+   ```bash
+   git stash pop
+   ```
+
+### Step 3: Ready to Work
+
+9. **Confirm setup** - Display:
+   - Current branch name
+   - Latest commit on main (to confirm sync)
+   - Working directory status
+
+## Branch Naming Conventions
+
+| Prefix | Purpose | Example |
+|--------|---------|---------|
+| `feature-` | New features | `feature-multiplayer-mode` |
+| `fix-` | Bug fixes | `fix-win-detection-edge-case` |
+| `docs-` | Documentation | `docs-api-reference` |
+| `refactor-` | Code refactoring | `refactor-game-state` |
+| `chore-` | Maintenance tasks | `chore-update-dependencies` |
+
+## Variables
+
+- `$BRANCH_NAME` - The name for the new feature branch (optional, will prompt if not provided)
+
+## Example Usage
+
+```
+# Start work on a new feature
+Start new work on feature-add-undo-move
+
+# Just sync main without creating a branch
+Sync main branch to latest
+
+# Start work (will prompt for branch name)
+Start new work
+```
+
+````

--- a/.github/prompts/submit.task.prompt.md
+++ b/.github/prompts/submit.task.prompt.md
@@ -1,30 +1,41 @@
 # Submit PR for Review
 
-Create a pull request and optionally squash merge after validation.
+Create a pull request and squash merge via GitHub (remote only - never merge locally).
+
+## Important
+
+- **NEVER** use local `git merge` commands to merge into `main` or `release`
+- **ALWAYS** use GitHub Pull Requests for merging
+- Squash merges are enforced at the repository level
+- The pre-commit hook blocks local commits to `main` and `release`
 
 ## Instructions
 
 ### Step 1: Create Pull Request (if not exists)
-1. **Check current branch** - Identify the feature branch name
-2. **Determine target branch** - Feature branches target `main`, release merges target `release`
-3. **Create PR** - Create a pull request with:
+1. **Check current branch** - Identify the feature branch name (must NOT be `main` or `release`)
+2. **Push branch to remote** - Ensure all commits are pushed: `git push -u origin <branch-name>`
+3. **Determine target branch** - Feature branches target `main`, release merges target `release`
+4. **Create PR via GitHub API** - Create a pull request with:
    - Clear, descriptive title summarizing the changes
    - Body describing what changed and why
    - Link to any related issues
+5. **Request Copilot review** - Automatically request GitHub Copilot code review for the PR
 
 ### Step 2: Validate PR (before merge)
-4. **Verify CI status** - Confirm all CI checks have passed
-5. **Check approval status** - Ensure the PR has been approved by reviewers (if required)
-6. **Review changes** - Summarize the key changes in the PR
+6. **Verify CI status** - Confirm all CI checks have passed
+7. **Check Copilot review** - Review and address any Copilot feedback
+8. **Check approval status** - Ensure the PR has been approved by reviewers (if required)
+9. **Review changes** - Summarize the key changes in the PR
 
-### Step 3: Squash Merge (when ready)
-7. **Verify target branch** - Confirm the PR targets the correct branch:
-   - Feature PRs should target `main` (for beta testing)
-   - Release PRs should merge `main` into `release` (for production)
-8. **Squash merge** - Merge using squash method with a clear commit message that:
-   - Uses the PR title as the commit title
-   - Includes PR number reference (e.g., `(#123)`)
-   - Summarizes all changes in the commit body
+### Step 3: Squash Merge via GitHub (when ready)
+10. **Verify target branch** - Confirm the PR targets the correct branch:
+    - Feature PRs should target `main` (for beta testing)
+    - Release PRs should merge `main` into `release` (for production)
+11. **Squash merge via GitHub API** - Use `gh pr merge --squash` or GitHub MCP tools:
+    - Uses the PR title as the commit title
+    - Includes PR number reference (e.g., `(#123)`)
+    - Summarizes all changes in the commit body
+12. **Delete feature branch** (optional) - Clean up after merge: `git branch -d <branch-name>`
 
 ## Branch Strategy
 

--- a/.github/workflows/validate-release-pr.yml
+++ b/.github/workflows/validate-release-pr.yml
@@ -1,0 +1,33 @@
+name: Validate PR Source Branch
+
+on:
+  pull_request:
+    branches:
+      - release
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  validate-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR source branch
+        run: |
+          SOURCE_BRANCH="${{ github.head_ref }}"
+          TARGET_BRANCH="${{ github.base_ref }}"
+          
+          echo "Source branch: $SOURCE_BRANCH"
+          echo "Target branch: $TARGET_BRANCH"
+          
+          if [[ "$TARGET_BRANCH" == "release" && "$SOURCE_BRANCH" != "main" ]]; then
+            echo "❌ ERROR: PRs to 'release' branch are only allowed from 'main' branch."
+            echo ""
+            echo "Current source: $SOURCE_BRANCH"
+            echo "Required source: main"
+            echo ""
+            echo "Workflow:"
+            echo "  1. Merge your changes to 'main' first"
+            echo "  2. Then create a PR from 'main' to 'release'"
+            exit 1
+          fi
+          
+          echo "✅ PR source branch is valid"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ cd gametime-tic-tac-toe
 
 # Install dependencies
 npm install
+
+# Configure git hooks (prevents commits to main/release)
+git config core.hooksPath .githooks
 ```
 
 ### Development


### PR DESCRIPTION
## Summary

This PR adds comprehensive branch workflow documentation and enforcement mechanisms to ensure proper Git workflow practices.

## Changes

### New Files
- **`.githooks/pre-commit`** - Pre-commit hook that prevents direct commits to `main` and `release` branches locally
- **`.github/prompts/start.task.prompt.md`** - New prompt for starting work with proper branch setup
- **`.github/workflows/validate-release-pr.yml`** - GitHub Actions workflow that enforces PRs to `release` can only come from `main`

### Updated Files
- **`.github/copilot-instructions.md`** - Added "Starting New Work" section with step-by-step branching workflow and Git hooks setup instructions
- **`.github/prompts/submit.task.prompt.md`** - Clarified that merges must happen via GitHub (remote only, never locally)
- **`.github/agents/speckit.implement.agent.md`** - Added Step 0 for branch setup verification before implementation
- **`.github/agents/speckit.tasks.agent.md`** - Added Step 0 for branch setup verification before task generation
- **`README.md`** - Added git hooks configuration step to installation instructions

## Branch Protection Configured (via GitHub API)

- ✅ `main` branch: Requires PR, squash merge only, Copilot auto-review enabled
- ✅ `release` branch: Requires PR, only accepts PRs from `main`, squash merge only

## Testing

- [x] Pre-commit hook blocks commits on `main` and `release`
- [x] Documentation is clear and actionable
- [x] Branch naming conventions documented