### PR TITLE
Fix E2E test 'should disable cells after win' timeout issue

### DIFF
--- a/tests/e2e/gameplay.spec.ts
+++ b/tests/e2e/gameplay.spec.ts
@@ -140,9 +140,12 @@ test.describe('Tic-Tac-Toe Game', () => {
       await cells.nth(4).click(); // O
       await cells.nth(2).click(); // X wins
 
-      // Try clicking an empty cell - should not work
-      await cells.nth(5).click();
-      await expect(cells.nth(5)).toHaveText('');
+      // Verify all empty cells are disabled after win
+      // Cells 5, 6, 7, 8 should be empty and disabled
+      await expect(cells.nth(5)).toBeDisabled();
+      await expect(cells.nth(6)).toBeDisabled();
+      await expect(cells.nth(7)).toBeDisabled();
+      await expect(cells.nth(8)).toBeDisabled();
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #8 - E2E test "should disable cells after win" times out due to incorrect test approach.

## Problem

The test at line 143 attempted to **click** a disabled cell to verify it was disabled:

```typescript
await cells.nth(5).click();
```

However, Playwright's `.click()` method waits for the element to be **enabled** before clicking, causing an infinite wait/timeout when the cell was correctly disabled.

## Solution

Replaced the click-based verification with proper Playwright assertions using `toBeDisabled()`:

```typescript
await expect(cells.nth(5)).toBeDisabled();
await expect(cells.nth(6)).toBeDisabled();
await expect(cells.nth(7)).toBeDisabled();
await expect(cells.nth(8)).toBeDisabled();
```

This approach:
- Uses idiomatic Playwright assertions
- Verifies all empty cells (not just one) are disabled after a win
- No longer causes timeouts

## Testing

- ✅ The specific test now passes in ~2 seconds
- ✅ All 18 E2E tests pass