### PR TITLE
docs: document automatic branch deletion after merge

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -62,6 +62,7 @@ This project uses **Cloudflare Pages** with Git integration for automatic deploy
 - Never commit directly to `main` or `release`
 - Merge to `main` for beta user testing
 - Only merge `main` to `release` for production releases
+- Feature branches are **automatically deleted** after squash merge via GitHub
 
 ### Git Hooks (Local Enforcement)
 

--- a/.github/prompts/submit.task.prompt.md
+++ b/.github/prompts/submit.task.prompt.md
@@ -35,7 +35,7 @@ Create a pull request and squash merge via GitHub (remote only - never merge loc
     - Uses the PR title as the commit title
     - Includes PR number reference (e.g., `(#123)`)
     - Summarizes all changes in the commit body
-12. **Delete feature branch** (optional) - Clean up after merge: `git branch -d <branch-name>`
+12. **Clean up local branch** - Remote branch is auto-deleted; remove local copy: `git branch -d <branch-name>`
 
 ## Branch Strategy
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ feature branch → main (beta) → release (production)
 2. **Beta Testing**: Merge to `main` for beta users to test
 3. **Production Release**: Merge `main` to `release` for production deployment
 
+> **Note**: Feature branches are automatically deleted after squash merge into `main`.
+
 ### Cloudflare Pages Configuration
 
 | Setting | Value |


### PR DESCRIPTION
## Summary

Documents the repository setting for automatic branch deletion after squash merge.

## Changes

- **`.github/copilot-instructions.md`**: Added branch rule noting feature branches are automatically deleted after squash merge
- **`.github/prompts/submit.task.prompt.md`**: Updated Step 12 to clarify remote branches are auto-deleted; only local cleanup needed
- **`README.md`**: Added note about automatic branch deletion in Deployment Workflow section

## Context

Configured via `gh repo edit --delete-branch-on-merge` to automatically clean up feature branches after they are merged into `main`.