### PR TITLE
feat: update release prompt to unlock/lock branch protection

### DIFF
--- a/.github/prompts/release.latest.prompt.md
+++ b/.github/prompts/release.latest.prompt.md
@@ -64,7 +64,7 @@ The trap handler below runs on shell EXIT. If you run these commands in an inter
   # Set up trap to always re-lock on exit (success, failure, or interruption)
   trap lock_branch EXIT
 
-  # ... rest of the steps go here in the subshell ...
+  # Execute the remaining release steps (e.g., steps 3–7) within this subshell context
 )
 ```
 


### PR DESCRIPTION
## Summary

Updates the release prompt to handle branch protection automatically.

## Changes

The `release.latest.prompt.md` now instructs the agent to:

1. **Unlock** the `release` branch before triggering the workflow
2. **Trigger** the release workflow
3. **Poll** for workflow completion
4. **Lock** the branch again (always, even on failure)
5. **Verify** the deployment

## Why

The `release` branch is now locked by default to prevent accidental direct pushes. This approach uses the human's local `gh` CLI credentials to manage branch protection, while the workflow only needs `contents: write` permission to push.

## Notes

- No PAT or GitHub App needed
- Branch protection is managed by the prompt runner, not the workflow