### PR TITLE
chore: add E2E tests to PR validation CI workflow

### DIFF
--- a/.github/workflows/validate-main-pr.yml
+++ b/.github/workflows/validate-main-pr.yml
@@ -28,5 +28,11 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Test
+      - name: Unit Tests
         run: npm test
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: E2E Tests
+        run: npm run test:e2e


### PR DESCRIPTION
## Summary

Adds Playwright E2E tests to the PR validation CI workflow to catch UI regressions before merge.

## Changes

- Renamed "Test" step to "Unit Tests" for clarity
- Added "Install Playwright Browsers" step using `--with-deps chromium` for efficient installs
- Added "E2E Tests" step that runs `npm run test:e2e`

## Workflow Now Runs

1. Lint
2. Build
3. Unit Tests
4. Install Playwright (chromium only)
5. E2E Tests

## Testing

- All local quality gates pass (typecheck, lint, unit tests, build)